### PR TITLE
Upstream backports for hid-sony.c

### DIFF
--- a/drivers/hid/hid-sony.c
+++ b/drivers/hid/hid-sony.c
@@ -1187,7 +1187,7 @@ static int sixaxis_set_operational_usb(struct hid_device *hdev)
 	struct usb_device *dev = interface_to_usbdev(intf);
 	__u16 ifnum = intf->cur_altsetting->desc.bInterfaceNumber;
 	int ret;
-	char *buf = kmalloc(18, GFP_KERNEL);
+	__u8 *buf = kmalloc(SIXAXIS_REPORT_0xF2_SIZE, GFP_KERNEL);
 
 	if (!buf)
 		return -ENOMEM;
@@ -1196,7 +1196,8 @@ static int sixaxis_set_operational_usb(struct hid_device *hdev)
 				 HID_REQ_GET_REPORT,
 				 USB_DIR_IN | USB_TYPE_CLASS |
 				 USB_RECIP_INTERFACE,
-				 (3 << 8) | 0xf2, ifnum, buf, 17,
+				 (3 << 8) | 0xf2, ifnum, buf,
+				 SIXAXIS_REPORT_0xF2_SIZE,
 				 USB_CTRL_GET_TIMEOUT);
 	if (ret < 0)
 		hid_err(hdev, "can't set operational mode\n");

--- a/drivers/hid/hid-sony.c
+++ b/drivers/hid/hid-sony.c
@@ -806,7 +806,7 @@ union sixaxis_output_report_01 {
 #define SIXAXIS_REPORT_0xF2_SIZE 17
 #define SIXAXIS_REPORT_0xF5_SIZE 8
 
-static spinlock_t sony_dev_list_lock;
+static DEFINE_SPINLOCK(sony_dev_list_lock);
 static LIST_HEAD(sony_device_list);
 static DEFINE_IDA(sony_device_id_allocator);
 
@@ -2072,6 +2072,8 @@ static int sony_probe(struct hid_device *hdev, const struct hid_device_id *id)
 		hid_err(hdev, "can't alloc sony descriptor\n");
 		return -ENOMEM;
 	}
+
+	spin_lock_init(&sc->lock);
 
 	sc->quirks = quirks;
 	hid_set_drvdata(hdev, sc);

--- a/drivers/hid/hid-sony.c
+++ b/drivers/hid/hid-sony.c
@@ -803,7 +803,7 @@ union sixaxis_output_report_01 {
 #define DS4_REPORT_0x05_SIZE 32
 #define DS4_REPORT_0x11_SIZE 78
 #define DS4_REPORT_0x81_SIZE 7
-#define SIXAXIS_REPORT_0xF2_SIZE 18
+#define SIXAXIS_REPORT_0xF2_SIZE 17
 
 static spinlock_t sony_dev_list_lock;
 static LIST_HEAD(sony_device_list);

--- a/drivers/hid/hid-sony.c
+++ b/drivers/hid/hid-sony.c
@@ -2224,8 +2224,8 @@ static void __exit sony_exit(void)
 {
 	dbg_hid("Sony:%s\n", __func__);
 
-	ida_destroy(&sony_device_id_allocator);
 	hid_unregister_driver(&sony_driver);
+	ida_destroy(&sony_device_id_allocator);
 }
 module_init(sony_init);
 module_exit(sony_exit);


### PR DESCRIPTION
This set of backports fixes uninitialized spinlocks, fixes a warning if someone uses rmmod to remove the driver while controllers are connected, cleans up some 'magic constant' usage and adds support for third-party GASIA and Speedlink Strike FX PS3 controllers that need some extra initialization steps to work (credit to Antonio Ospite, Andrew Haines and Lauri Kasanen for this).
