### PR TITLE
xpad (xbox controller family) fixes

### DIFF
--- a/drivers/input/joystick/xpad.c
+++ b/drivers/input/joystick/xpad.c
@@ -881,7 +881,7 @@ static int xpad_init_output(struct usb_interface *intf, struct usb_xpad *xpad)
 
 static void xpad_stop_output(struct usb_xpad *xpad)
 {
-	if (xpad->xtype != XTYPE_UNKNOWN)
+	if (xpad->xtype != XTYPE_UNKNOWN && xpad->xtype != XTYPE_XBOX360W)
 		usb_kill_urb(xpad->irq_out);
 }
 
@@ -1333,6 +1333,8 @@ static int xpad_probe(struct usb_interface *intf, const struct usb_device_id *id
 		xpad->irq_out->transfer_buffer_length = 12;
 		usb_submit_urb(xpad->irq_out, GFP_KERNEL);
 		spin_unlock(&xpad->odata_lock);
+
+		xpad->pad_present = 0;
 	} else {
 		my_work_t *work;
 		xpad->pad_present = 1;

--- a/drivers/input/joystick/xpad.c
+++ b/drivers/input/joystick/xpad.c
@@ -989,15 +989,6 @@ static int xpad_init_ff(struct usb_xpad *xpad)
 static int xpad_init_ff(struct usb_xpad *xpad) { return 0; }
 #endif
 
-#if defined(CONFIG_JOYSTICK_XPAD_LEDS)
-#include <linux/leds.h>
-
-struct xpad_led {
-	char name[16];
-	struct led_classdev led_cdev;
-	struct usb_xpad *xpad;
-};
-
 static void xpad_send_led_command(struct usb_xpad *xpad, int command)
 {
 	if ((unsigned)command > 15)
@@ -1033,6 +1024,15 @@ static void xpad_send_led_command(struct usb_xpad *xpad, int command)
 	usb_submit_urb(xpad->irq_out, GFP_KERNEL);
 	spin_unlock(&xpad->odata_lock);
 }
+
+#if defined(CONFIG_JOYSTICK_XPAD_LEDS)
+#include <linux/leds.h>
+
+struct xpad_led {
+	char name[16];
+	struct led_classdev led_cdev;
+	struct usb_xpad *xpad;
+};
 
 static void xpad_led_set(struct led_classdev *led_cdev,
 			 enum led_brightness value)

--- a/drivers/input/joystick/xpad.c
+++ b/drivers/input/joystick/xpad.c
@@ -327,6 +327,13 @@ static void xpad_process_packet(struct usb_xpad *xpad, u16 cmd, unsigned char *d
 {
 	struct input_dev *dev = xpad->dev;
 
+	if (!dev) {
+		/* at startup we might start getting input packets before there's a
+		 kernel input device set up to receive events - avoid crash. */
+		dev_dbg(&xpad->intf->dev, "skipping input packet aimed at unbound input device");
+		return;
+	}
+
 	if (!(xpad->mapping & MAP_STICKS_TO_NULL)) {
 		/* left stick */
 		input_report_abs(dev, ABS_X,
@@ -397,6 +404,13 @@ static void xpad360_process_packet(struct usb_xpad *xpad,
 				   u16 cmd, unsigned char *data)
 {
 	struct input_dev *dev = xpad->dev;
+
+	if (!dev) {
+		/* at startup we might start getting input packets before there's a
+		 kernel input device set up to receive events - avoid crash. */
+		dev_dbg(&xpad->intf->dev, "skipping input packet aimed at unbound input device");
+		return;
+	}
 
 	/* digital pad */
 	if (xpad->mapping & MAP_DPAD_TO_BUTTONS) {
@@ -701,6 +715,13 @@ static void xpadone_process_packet(struct usb_xpad *xpad,
 				u16 cmd, unsigned char *data)
 {
 	struct input_dev *dev = xpad->dev;
+
+	if (!dev) {
+		/* at startup we might start getting input packets before there's a
+		 kernel input device set up to receive events - avoid crash. */
+		dev_dbg(&xpad->intf->dev, "skipping input packet aimed at unbound input device");
+		return;
+	}
 
 	switch (data[0]) {
 	case 0x20:


### PR DESCRIPTION
This fixes one crash, one kernel warning, one semi-broken feature and one obscure build failure.
More details on each individual commit message.

Tested as a dkms module on kernel 3.13.0(-29) in Ubuntu 14.04.
