### PR TITLE
Sony controller fixes for Brewmaster

### DIFF
--- a/drivers/hid/hid-sony.c
+++ b/drivers/hid/hid-sony.c
@@ -1040,6 +1040,17 @@ static int sony_raw_event(struct hid_device *hdev, struct hid_report *report,
 	 * has to be BYTE_SWAPPED before passing up to joystick interface
 	 */
 	if ((sc->quirks & SIXAXIS_CONTROLLER) && rd[0] == 0x01 && size == 49) {
+		/*
+		 * When connected via Bluetooth the Sixaxis occasionally sends
+		 * a report with the second byte 0xff and the rest zeroed.
+		 *
+		 * This report does not reflect the actual state of the
+		 * controller and must be ignored to avoid generating false
+		 * input events.
+		 */
+		if (rd[1] == 0xff)
+			return -EINVAL;
+
 		swap(rd[41], rd[42]);
 		swap(rd[43], rd[44]);
 		swap(rd[45], rd[46]);

--- a/drivers/hid/hid-sony.c
+++ b/drivers/hid/hid-sony.c
@@ -1577,7 +1577,7 @@ static void dualshock4_state_worker(struct work_struct *work)
 	} else {
 		memset(buf, 0, DS4_REPORT_0x11_SIZE);
 		buf[0] = 0x11;
-		buf[1] = 0xB0;
+		buf[1] = 0x80;
 		buf[3] = 0x0F;
 		offset = 6;
 	}


### PR DESCRIPTION
The first two commits in this series are bug fixes:

The first causes the driver to ignore the invalid zeroed state packets that the Sixaxis periodically sends.  These zeroed packets caused false button/stick release events that did not reflect the controller state.

The second is Rostislav Pehlivanov's fix for the Dualshock 4 polling rate.  The current output reports contain a value that sets the DS4 polling rate to a low value and causes some setups to report a low signal error.  This patch sets the controller to the full polling rate which corrects this issue.

The other two commits are just bringing back the patches from Alchemy that use the joydev device number to set the initial LED values and stops the Sixaxis LEDs from blinking after the PS button is pushed.
