### PR TITLE
Remove the size check for the Dualshock 4 HID Descriptor

### DIFF
--- a/drivers/hid/hid-sony.c
+++ b/drivers/hid/hid-sony.c
@@ -912,11 +912,11 @@ static __u8 *sony_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 	 * the gyroscope values to corresponding axes so we need a
 	 * modified one.
 	 */
-	if ((sc->quirks & DUALSHOCK4_CONTROLLER_USB) && *rsize == 467) {
+	if (sc->quirks & DUALSHOCK4_CONTROLLER_USB) {
 		hid_info(hdev, "Using modified Dualshock 4 report descriptor with gyroscope axes\n");
 		rdesc = dualshock4_usb_rdesc;
 		*rsize = sizeof(dualshock4_usb_rdesc);
-	} else if ((sc->quirks & DUALSHOCK4_CONTROLLER_BT) && *rsize == 357) {
+	} else if (sc->quirks & DUALSHOCK4_CONTROLLER_BT) {
 		hid_info(hdev, "Using modified Dualshock 4 Bluetooth report descriptor\n");
 		rdesc = dualshock4_bt_rdesc;
 		*rsize = sizeof(dualshock4_bt_rdesc);


### PR DESCRIPTION
In the last few days people have been reporting that new Dualshock 4 controllers aren't working correctly.  Sony made some change to the HID descriptor that caused the size to change and as a result the size check in the module function that replaces the HID descriptor was failing.  This removes the size check so that current controllers work and any future changes to the controllers won't have the same problem.
