### PR TITLE
Update core.h

### DIFF
--- a/drivers/net/wireless/ath/ath10k/core.h
+++ b/drivers/net/wireless/ath/ath10k/core.h
@@ -440,6 +440,15 @@ enum ath10k_fw_features {
 	 */
 	ATH10K_FW_FEATURE_MULTI_VIF_PS_SUPPORT = 5,
 
+	/* Some firmware revisions have an incomplete WoWLAN implementation
+	 * despite WMI service bit being advertised. This feature flag is used
+	 * to distinguish whether WoWLAN is really supported or not.
+	 */
+ 	ATH10K_FW_FEATURE_WOWLAN_SUPPORT = 6,
+ 
+	/* Don't trust error code from otp.bin */
+	ATH10K_FW_FEATURE_IGNORE_OTP_RESULT,
+	
 	/* keep last */
 	ATH10K_FW_FEATURE_COUNT,
 };


### PR DESCRIPTION
ath10k: add ATH10K_FW_FEATURE_IGNORE_OTP_RESULT
qca6174 otp binary seems to always return an error to the host, even if the
calibration succeeded. Add a firmware feature flag to detect if the firmware
image which have this problem and workaround the issue in ath10k by ignoring
the error code.

I was also considering making this hw specific flag but as this is strictly a
firmware issue it's best to handle this via a firmware feature flag so that it
will be easy to disable the workaround.

Signed-off-by: Kalle Valo kvalo@qca.qualcomm.com
