### PR TITLE
Add Support for Wooting Keyboards

### DIFF
--- a/drivers/input/joystick/xpad.c
+++ b/drivers/input/joystick/xpad.c
@@ -126,6 +126,8 @@ static const struct xpad_device {
 	u8 mapping;
 	u8 xtype;
 } xpad_device[] = {
+	{ 0x03eb, 0xff01, "Wooting WootingOne (Xinput)", 0, XTYPE_XBOX360 },
+	{ 0x03eb, 0xff02, "Wooting WootingTwo (Xinput)", 0, XTYPE_XBOX360 },
 	{ 0x045e, 0x0202, "Microsoft X-Box pad v1 (US)", 0, XTYPE_XBOX },
 	{ 0x045e, 0x0285, "Microsoft X-Box pad (Japan)", 0, XTYPE_XBOX },
 	{ 0x045e, 0x0287, "Microsoft Xbox Controller S", 0, XTYPE_XBOX },
@@ -313,6 +315,7 @@ static const signed short xpad_abs_triggers[] = {
 
 static struct usb_device_id xpad_table[] = {
 	{ USB_INTERFACE_INFO('X', 'B', 0) },	/* X-Box USB-IF not approved class */
+	XPAD_XBOX360_VENDOR(0x03eb),		/* Wooting Keyboards */
 	XPAD_XBOX360_VENDOR(0x044f),		/* Thrustmaster X-Box 360 controllers */
 	XPAD_XBOX360_VENDOR(0x045e),		/* Microsoft X-Box 360 controllers */
 	XPAD_XBOXONE_VENDOR(0x045e),		/* Microsoft X-Box One controllers */


### PR DESCRIPTION
Add USB identifiers for WootingOne and WootingTwo keyboards' Xinput 
analog mode.

Note that, in order to assist users with differentiation from the keyboards' DirectInput mode, I explicitly append '(Xinput)'  to the device identifier names; let me know if you'd rather the device name did not include that addition.